### PR TITLE
React translation with rt tag

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["es2015", "stage-3"],
   "env": {
     "test": {
+      "presets": ["react", "es2015", "stage-3"],
       "plugins": ["rewire"]
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-loader": "^6.4.0",
     "babel-plugin-rewire": "1.0.0",
     "babel-preset-es2015": "6.18.0",
+    "babel-preset-react": "^6.23.0",
     "babel-preset-stage-3": "6.17.0",
     "chai": "3.5.0",
     "eslint": "2.13.1",
@@ -45,6 +46,7 @@
     "gitbook-plugin-ga": "1.0.1",
     "gitbook-plugin-github-buttons": "2.1.0",
     "mocha": "3.1.2",
+    "react": "^15.4.2",
     "sinon": "1.17.7",
     "webpack": "^2.2.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { getMsgid, msgid2Orig, buildStr, makePluralFunc,
     getPluralFunc, defaultHeaders } from './utils';
+import { getReactMsgid, reactMsgid2Orig, buildArr } from './react-utils';
 
 const locales = {};
 let currentLocale;
@@ -13,6 +14,15 @@ export function t(strings, ...exprs) {
         const id = getMsgid(strings, exprs);
         const transObj = findTransObj(currentLocale, id);
         return transObj ? msgid2Orig(transObj.msgstr[0], exprs) : id;
+    }
+    return strings;
+}
+
+export function rt(strings, ...exprs) {
+    if (strings && strings.reduce) {
+        const id = getReactMsgid(strings, exprs);
+        const transObj = findTransObj(currentLocale, id);
+        return transObj ? reactMsgid2Orig(transObj.msgstr[0], exprs) : buildArr(strings, exprs);
     }
     return strings;
 }

--- a/src/react-utils.js
+++ b/src/react-utils.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { reg } from './utils';
+const reactSymbol = Symbol.for('react.element');
+
+function isReactEl(el) {
+    return el.$$typeof === reactSymbol;
+}
+
+export const buildArr = (strs, exprs) => strs.reduce((r, s, i) => r.concat(s).concat(exprs[i] || ''), []);
+
+export const getReactMsgid = (strs, exprs) => {
+    const result = [];
+    let reactElsCount = 0;
+
+    strs.forEach((str, i) => {
+        let chunk = str;
+        const expr = exprs[i];
+        if (typeof expr === 'object' && isReactEl(expr)) {
+            if (typeof expr.props.children === 'string') {
+                chunk += `<${reactElsCount}>${expr.props.children}</${reactElsCount}>`;
+            } else {
+                chunk += `\${ ${i} }`;
+            }
+            reactElsCount += 1;
+        } else if (expr !== undefined) {
+            chunk += `\${ ${i} }`;
+        }
+        result.push(chunk);
+    });
+
+    return result.join('');
+};
+
+export const reactMsgid2Orig = (id, exprs) => {
+    let cloneId = id.slice();
+    const result = [];
+    let reactIndex = 0;
+    let simpleIndex = 0;
+
+    const termReg = /^(.*?)[<\$]/;
+    const reactReg = (i) => new RegExp(`<${i}>(.*)<\/${i}>`);
+    let match = cloneId.match(termReg);
+    let exprIdx = 0;
+    while (match) {
+        result.push(match[1]);
+        cloneId = cloneId.replace(new RegExp(`^${match[1]}`), '');
+        if (cloneId[0] === '<') {
+            const [tagEl, children] = cloneId.match(reactReg(reactIndex));
+            cloneId = cloneId.replace(tagEl, '');
+            const expr = exprs[exprIdx];
+            const newExpr = React.cloneElement(expr, expr.props, children);
+            result.push(newExpr);
+            reactIndex += 1;
+            exprIdx += 1;
+        }
+        if (cloneId[0] === '$') {
+            const el = cloneId.match(reg(simpleIndex))[0];
+            cloneId = cloneId.replace(el, '');
+            result.push(exprs[exprIdx]);
+            simpleIndex += 1;
+            exprIdx += 1;
+        }
+        match = cloneId.match(termReg);
+    }
+
+    return result;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,35 +2,6 @@ export const getMsgid = (str, exprs) => {
     return str.reduce((s, l, i) => s + l + (exprs[i] !== undefined && `\${ ${i} }` || ''), '');
 };
 
-const reactSymbol = Symbol.for('react.element');
-
-function isReactEl(el) {
-    return el.$$typeof === reactSymbol;
-}
-
-export const getReactMsgid = (strs, exprs) => {
-    const result = [];
-    let reactElsCount = 0;
-
-    strs.forEach((str, i) => {
-        let chunk = str;
-        const expr = exprs[i];
-        if (typeof expr === 'object' && isReactEl(expr)) {
-            if (typeof expr.props.children === 'string') {
-                chunk += `<${reactElsCount}>${expr.props.children}</${reactElsCount}>`;
-            } else {
-                chunk += `\${ ${i} }`;
-            }
-            reactElsCount += 1;
-        } else if (expr !== undefined) {
-            chunk += `\${ ${i} }`;
-        }
-        result.push(chunk);
-    });
-
-    return result.join('');
-};
-
 const mem = {};
 const memoize1 = (f) => (arg) => {
     if (mem[arg]) {
@@ -40,7 +11,7 @@ const memoize1 = (f) => (arg) => {
     return mem[arg];
 };
 
-const reg = (i) => new RegExp(`\\$\\{([\\s]+?|\\s?)${i}([\\s]+?|\\s?)}`);
+export const reg = (i) => new RegExp(`\\$\\{([\\s]+?|\\s?)${i}([\\s]+?|\\s?)}`);
 const memReg = memoize1(reg);
 
 export const msgid2Orig = (id, exprs) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,35 @@ export const getMsgid = (str, exprs) => {
     return str.reduce((s, l, i) => s + l + (exprs[i] !== undefined && `\${ ${i} }` || ''), '');
 };
 
+const reactSymbol = Symbol.for('react.element');
+
+function isReactEl(el) {
+    return el.$$typeof === reactSymbol;
+}
+
+export const getReactMsgid = (strs, exprs) => {
+    const result = [];
+    let reactElsCount = 0;
+
+    strs.forEach((str, i) => {
+        let chunk = str;
+        const expr = exprs[i];
+        if (typeof expr === 'object' && isReactEl(expr)) {
+            if (typeof expr.props.children === 'string') {
+                chunk += `<${reactElsCount}>${expr.props.children}</${reactElsCount}>`;
+            } else {
+                chunk += `\${ ${i} }`;
+            }
+            reactElsCount += 1;
+        } else if (expr !== undefined) {
+            chunk += `\${ ${i} }`;
+        }
+        result.push(chunk);
+    });
+
+    return result.join('');
+};
+
 const mem = {};
 const memoize1 = (f) => (arg) => {
     if (mem[arg]) {

--- a/tests/test_react_utils.js
+++ b/tests/test_react_utils.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { expect } from 'chai';
+import { getReactMsgid, reactMsgid2Orig } from '../src/react-utils';
+
+function getStrsExprs(strs, ...exprs) {
+    return [strs, exprs];
+}
+
+describe('utils getReactMsgid', () => {
+    it('should resolve msgid for jsx elements', () => {
+        const a = 0;
+        const [strs, exprs] = getStrsExprs`click ${<a href=''>here</a>}`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('click <0>here</0>');
+    });
+    it('should increment react els count', () => {
+        const a = 0;
+        const [strs, exprs] = getStrsExprs`click ${<a href=''>here</a>} and ${<a href=''>here</a>}`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('click <0>here</0> and <1>here</1>');
+    });
+
+    it('should work with mix of react and other expressions', () => {
+        const a = 0;
+        const user = 'John';
+        const [strs, exprs] = getStrsExprs`Hello ${user} click ${<a href=''>here</a>} and ${<a href=''>there</a>}`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 } click <0>here</0> and <1>there</1>');
+    });
+
+    it('should not apply <0> tags if children is not a string', () => {
+        const userName = 'John';
+        const [strs, exprs] = getStrsExprs`Hello ${<b>dear {userName}</b>}`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 }');
+    });
+
+    it('should work with a single tag elements', () => {
+        const [strs, exprs] = getStrsExprs`Hello ${<br />} username`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 } username');
+    });
+});
+
+describe('utils reactMsgid2Orig', () => {
+    it('should resolve original string', () => {
+        const [str, element] = reactMsgid2Orig('Click <0>Here [translated]</0>', [<a href=''>here</a>]);
+        expect(str).to.be.eql('Click ');
+        expect(element.props.children).to.eql('Here [translated]');
+    });
+    it('should resolve original string with multiple jsx components', () => {
+        const [str1, el1, str2, el2] = reactMsgid2Orig('Click <0>Here [translated]</0> <1>There [translated]</1>',
+            [<a href=''>here</a>, <a href=''>there</a>]);
+        expect(str1).to.be.eql('Click ');
+        expect(el1.props.children).to.eql('Here [translated]');
+        expect(str2).to.be.eql(' ');
+        expect(el2.props.children).to.be.eql('There [translated]');
+    });
+    it('should resolve mixed type of expressions', () => {
+        const [str, el1, str2, exp] = reactMsgid2Orig('Click <0>Here [translated]</0> ${ 0 }',
+            [<a href=''>here</a>, 5]);
+        expect(str).to.be.eql('Click ');
+        expect(el1.props.children).to.eql('Here [translated]');
+        expect(str2).to.be.eql(' ');
+        expect(exp).to.be.eql(5);
+    });
+});

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -1,5 +1,6 @@
+import React from 'react';
 import { expect } from 'chai';
-import { getMsgid } from '../src/utils';
+import { getMsgid, getReactMsgid } from '../src/utils';
 
 function getStrsExprs(strs, ...exprs) {
     return [strs, exprs];
@@ -16,5 +17,36 @@ describe('utils getMsgid', () => {
         const a = 0;
         const [strs, exprs] = getStrsExprs`test ${a}`;
         expect(getMsgid(strs, exprs)).to.be.eql('test ${ 0 }');
+    });
+});
+
+describe('utils getReactMsgid', () => {
+    it('should resolve msgid for jsx elements', () => {
+        const a = 0;
+        const [strs, exprs] = getStrsExprs`click ${<a href=''>here</a>}`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('click <0>here</0>');
+    });
+    it('should increment react els count', () => {
+        const a = 0;
+        const [strs, exprs] = getStrsExprs`click ${<a href=''>here</a>} and ${<a href=''>here</a>}`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('click <0>here</0> and <1>here</1>');
+    });
+
+    it('should work with mix of react and other expressions', () => {
+        const a = 0;
+        const user = 'John';
+        const [strs, exprs] = getStrsExprs`Hello ${user} click ${<a href=''>here</a>} and ${<a href=''>there</a>}`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 } click <0>here</0> and <1>there</1>');
+    });
+
+    it('should not apply <0> tags if children is not a string', () => {
+        const userName = 'John';
+        const [strs, exprs] = getStrsExprs`Hello ${<b>dear {userName}</b>}`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 }');
+    });
+
+    it('should work with a single tag elements', () => {
+        const [strs, exprs] = getStrsExprs`Hello ${<br />} username`;
+        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 } username');
     });
 });

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -1,6 +1,5 @@
-import React from 'react';
 import { expect } from 'chai';
-import { getMsgid, getReactMsgid } from '../src/utils';
+import { getMsgid } from '../src/utils';
 
 function getStrsExprs(strs, ...exprs) {
     return [strs, exprs];
@@ -17,36 +16,5 @@ describe('utils getMsgid', () => {
         const a = 0;
         const [strs, exprs] = getStrsExprs`test ${a}`;
         expect(getMsgid(strs, exprs)).to.be.eql('test ${ 0 }');
-    });
-});
-
-describe('utils getReactMsgid', () => {
-    it('should resolve msgid for jsx elements', () => {
-        const a = 0;
-        const [strs, exprs] = getStrsExprs`click ${<a href=''>here</a>}`;
-        expect(getReactMsgid(strs, exprs)).to.be.eql('click <0>here</0>');
-    });
-    it('should increment react els count', () => {
-        const a = 0;
-        const [strs, exprs] = getStrsExprs`click ${<a href=''>here</a>} and ${<a href=''>here</a>}`;
-        expect(getReactMsgid(strs, exprs)).to.be.eql('click <0>here</0> and <1>here</1>');
-    });
-
-    it('should work with mix of react and other expressions', () => {
-        const a = 0;
-        const user = 'John';
-        const [strs, exprs] = getStrsExprs`Hello ${user} click ${<a href=''>here</a>} and ${<a href=''>there</a>}`;
-        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 } click <0>here</0> and <1>there</1>');
-    });
-
-    it('should not apply <0> tags if children is not a string', () => {
-        const userName = 'John';
-        const [strs, exprs] = getStrsExprs`Hello ${<b>dear {userName}</b>}`;
-        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 }');
-    });
-
-    it('should work with a single tag elements', () => {
-        const [strs, exprs] = getStrsExprs`Hello ${<br />} username`;
-        expect(getReactMsgid(strs, exprs)).to.be.eql('Hello ${ 0 } username');
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,8 @@ module.exports = {
         rules: [
             {test: /\.(js|jsx)$/, use: 'babel-loader'}
         ]
-
+    },
+    externals: {
+        react: 'react',
     }
 };


### PR DESCRIPTION
Work is still in progress

Already implemented:

### Retreive msgid for

#### 1. Nested react elements:
```jsx
`click ${<a href=''>here</a>}`
// click <0>here</0>
```

#### 2. Multiple nested react elements:
```jsx
`click ${<a href=''>here</a>} and ${<a href=''>here</a>}`
// click <0>here</0> and <1>here</1>
```

#### 3. Mix react and non reac elements:
```jsx
`Hello ${user} click ${<a href=''>here</a>} and ${<a href=''>there</a>}`
// 'Hello ${ 0 } click <0>here</0> and <1>there</1>'
```

#### 4. Single tag elements:
I think there is no need to fetch single tag elements in form of `<0>`, just use old `${ 0 }` for that.
```jsx
`Hello ${<br />} username`
// 'Hello ${ 0 } username'
```

#### 5. Complex nested react components:
If props.children is not string use old `${ 0 }` format for that:
```jsx
`Hello ${ <span>dear <item>username</item></span>}`
// 'Hello ${ 0 }'
```
