### PR TITLE
Fix dedent for t and ngettext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export function gettext(id) {
 
 export function ngettext(...args) {
     const { currentLocale, locales } = config;
-    const id = getMsgid(args[0]._strs, args[0]._exprs);
+    const id = maybeDedent(getMsgid(args[0]._strs, args[0]._exprs));
     const n = args[args.length - 1];
     const trans = findTransObj(currentLocale, id);
     const headers = trans ? locales[currentLocale].headers : config.headers;

--- a/src/index.js
+++ b/src/index.js
@@ -13,15 +13,19 @@ function findTransObj(locale, str) {
     return locales[locale] ? locales[locale].translations[''][str] : null;
 }
 
+function maybeDedent(str) {
+    return config.dedent ? dedentIfConfig(config, str) : str;
+}
+
 export function t(strings, ...exprs) {
     const curLocale = config.currentLocale;
     let result = strings;
     if (strings && strings.reduce) {
-        const id = getMsgid(strings, exprs);
+        const id = maybeDedent(getMsgid(strings, exprs));
         const transObj = findTransObj(curLocale, id);
         result = transObj ? msgid2Orig(transObj.msgstr[0], exprs) : buildStr(strings, exprs);
     }
-    return dedentIfConfig(config, result);
+    return maybeDedent(result);
 }
 
 const separator = /(\${\s*\d+\s*})/g;
@@ -80,7 +84,7 @@ export function ngettext(...args) {
         result = msgid2Orig(pluralFn(n, trans.msgstr), args[0]._exprs);
     }
 
-    return dedentIfConfig(config, result);
+    return maybeDedent(result);
 }
 
 export function addLocale(locale, data, replaceVariablesNames = true) {

--- a/tests/test_ngettext.js
+++ b/tests/test_ngettext.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ngettext, useLocale, msgid, setDefaultHeaders } from '../src/index';
+import { ngettext, useLocale, msgid, setDefaultHeaders, addLocale } from '../src/index';
 import { loadLocale } from '../src/loader';
 
 describe('ngettext', () => {
@@ -54,5 +54,32 @@ describe('ngettext', () => {
         const a = 2;
         const result = ngettext(msgid`${a} банан`, `${a} банана`, `${a} бананів`, a);
         expect(result).to.eql('2 банана');
+        setDefaultHeaders({ 'plural-forms': 'nplurals=2; plural=(n!=1);' });
+    });
+
+    it('should work with multiline dedent', () => {
+        const ukLocale = {
+            headers: {
+                'plural-forms': 'nplurals=3; ' +
+                'plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);',
+            },
+            translations: {
+                '': {
+                    '${ 0 }\nhour': {
+                        msgid: '${ 0 }\nhour',
+                        msgid_plural: '${ 0 }\nhours',
+                        msgstr: ['${ 0 }\nгодина', '${ 0 }\nгодини', '${ 0 }\nгодин'],
+                    },
+                },
+            },
+        };
+        addLocale('uk', ukLocale);
+        useLocale(('uk'));
+        const n = 2;
+        const result = ngettext(msgid`${n}
+            hour`,
+            `${n}
+            hours`, n);
+        expect(result).to.eql('2\nгодини');
     });
 });

--- a/tests/test_t.js
+++ b/tests/test_t.js
@@ -56,7 +56,7 @@ describe('t', () => {
         const str = t`this is multiline
         demo for demonstrating
         multiline strings`;
-        const expected = `this is multiline\ndemo for demonstrating\nmultiline strings`;
+        const expected = `this is multiline\ndemo for demonstrating\nmultiline strings [translated]`;
         expect(str).to.eql(expected);
     });
 });


### PR DESCRIPTION
Regarding to this issue - https://github.com/c-3po-org/c-3po/issues/66.

There is no need for `jt` fix, because it is used in scope of html markup so all dedent symbols are not displayed.
@alxpy @MrOrz 