### PR TITLE
Allow supplying locale to translation functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,24 +24,31 @@ function maybeDedent(str) {
     return config.dedent ? dedentIfConfig(config, str) : str;
 }
 
-export function t(strings, ...exprs) {
-    const curLocale = config.currentLocale;
+
+export function tWithLocale(locale, strings, ...exprs) {
     let result = strings;
     if (strings && strings.reduce) {
         const id = maybeDedent(getMsgid(strings, exprs));
-        const transObj = findTransObj(curLocale, id);
+        const transObj = findTransObj(locale, id);
         result = transObj ? msgid2Orig(transObj.msgstr[0], exprs) : buildStr(strings, exprs);
     }
     return maybeDedent(result);
 }
 
+
+export function t(strings, ...exprs) {
+    return tWithLocale(config.currentLocale, strings, ...exprs);
+}
+
+
 const separator = /(\${\s*\d+\s*})/g;
 const slotIdRegexp = /\${\s*(\d+)\s*}/;
 
-export function jt(strings, ...exprs) {
+
+export function jtWithLocale(locale, strings, ...exprs) {
     if (strings && strings.reduce) {
         const id = getMsgid(strings, exprs);
-        const transObj = findTransObj(config.currentLocale, id);
+        const transObj = findTransObj(locale, id);
         if (!transObj) return buildArr(strings, exprs);
 
         // splits string & capturing group into tokens
@@ -57,6 +64,10 @@ export function jt(strings, ...exprs) {
     return strings;
 }
 
+export function jt(strings, ...exprs) {
+    return jtWithLocale(config.currentLocale, strings, ...exprs);
+}
+
 export function msgid(strings, ...exprs) {
     /* eslint-disable no-new-wrappers */
     if (strings && strings.reduce) {
@@ -69,13 +80,12 @@ export function msgid(strings, ...exprs) {
     return strings;
 }
 
-export function gettext(id) {
-    const transObj = findTransObj(config.currentLocale, id);
+export function gettext(id, locale = null) {
+    const transObj = findTransObj(locale || config.currentLocale, id);
     return transObj ? transObj.msgstr[0] : id;
 }
 
-export function ngettext(...args) {
-    const { currentLocale, locales } = config;
+export function ngettextWithLocale({ currentLocale, locales }, ...args) {
     const id = maybeDedent(getMsgid(args[0]._strs, args[0]._exprs));
     const n = args[args.length - 1];
     const trans = findTransObj(currentLocale, id);
@@ -92,6 +102,10 @@ export function ngettext(...args) {
     }
 
     return maybeDedent(result);
+}
+
+export function ngettext(...args) {
+    return ngettextWithLocale(config, ...args);
 }
 
 export function addLocale(locale, data, replaceVariablesNames = true) {


### PR DESCRIPTION
Hey, my first pull request to this library! :)

In a recent app I need a fallback strategy to search for strings in multiple localizations (for example: `de_CH` -> `de` -> `en-US` -> untranslated original string).

To implement this without the side effects of multiple `setLocale()` calls that would change the current locale globally, I added a way to c-3po to supply a locale from the outside as argument to the translation function.

Example usage:
```javascript
import { uniq, flatten } from 'lodash';
import { tWithLocale, addLocale } from 'c-3po';

const defaultLocale = 'en_US';

addLocale('de_AT', …);
addLocale('de', …);
addLocale('en_US', …);
addLocale('en', …);

// Returns the locale as language code without country code etc. removed
// (for example "en" if given "en-GB").

function localeWithoutCountry(locale: string): string {
  return locale.substring(0, 2);
}


// Returns an expanded list of preferred locales.
export function expandedPreferredLocales() {
  // Note that some browsers don't support navigator.languages
  const localesPreferredByUser = window.navigator.languages || [];
  const locales = localesPreferredByUser.concat([window.navigator.language, defaultLocale]);

  // Try all locales without country code, too
  return uniq(flatten(locales.map(l => [l, localeWithoutCountry(l)])));
}

// This is the wrapped c-3po `t` function used throughout my app
export function t(...args) {
  for (const locale of expandedPreferredLocales()) {
    const translatedString = tWithLocale(locale, ...args);
    if (translatedString) return translatedString;
  }
  return args[0]; // return the untranslated string as last option
}
```

I did not change any existing interfaces.

Tests are green, I didn't add any new ones for the new methods though yet.

This works well for me and I think it's a cool feature. Maybe for others, too? What do you think?